### PR TITLE
CVE-2013-7440 doesn't apply to Python 2.7

### DIFF
--- a/vulnerabilities.yaml
+++ b/vulnerabilities.yaml
@@ -492,6 +492,9 @@
     Change behavior of ``ssl.match_hostname()`` to follow RFC 6125, for
     security reasons.  It now doesn't match multiple wildcards nor wildcards
     inside IDN fragments.
+    Note that this function was only added to Python 2.7 in a backport to 2.7.9,
+    and was added in its fixed form, so no releases of Python 2.7 have this
+    vulnerability.
 
 - name: "zipfile DoS using malformed file"
   cve: CVE-2013-7338


### PR DESCRIPTION
Add a note explaining that although the CVE description says that this affects versions of Python 2.7 before 2.7.9, the `match_hostname` function was actually only added in 2.7.9, and was added with this fix already applied.
(It's hard to trawl through the history and work out what's happening otherwise)

See [commit daeb925cc88cc8fed2030166ade641de28edb396](https://github.com/python/cpython/commit/daeb925cc88cc8fed2030166ade641de28edb396#diff-c49248c7181161e24048bec5e35ba953R185) to cpython for when the actual change was made.