### PR TITLE
PyPI 2022-05-24: remove comment regarding email protections

### DIFF
--- a/pypi-vuln/index-2022-05-24-ctx-domain-takeover.rst
+++ b/pypi-vuln/index-2022-05-24-ctx-domain-takeover.rst
@@ -162,14 +162,6 @@ publicly visible email addresses associated with project metadata containing
 expired domains, which happened to match the domains of owner user accounts for
 projects.
 
-Currently, PyPI has some protections in place for expired email domains: if
-PyPI sends an email to a user's email address, and that email bounces, PyPI
-will disable the verified status of that email. As password resets require
-verified email addresses, an attacker would be unable to use the expired domain
-to gain access to the account. However, this depends on PyPI sending an email
-to the expired domain in the time period between expiry and an attacker
-attempting a takeover.
-
 Performing this analysis on an ongoing basis and freezing accounts with expired
 or near expiration domains is a potential mitigation that could protect absent
 maintainers in the future, at the cost of increased support burden on the team


### PR DESCRIPTION
this paragraph is inaccurate, we do not require a verified email address to perform a password reset, see https://github.com/pypa/warehouse/blob/bd81ae8bae40fcd2736e47b65912db297a993339/warehouse/accounts/models.py#L165-L174 which is the only gate on password reset requests.

the email verification concerns noted in this paragraph are more to do with deliverability and reputation than security and would not have changed the course of this incident.