### PR TITLE
Removing taken-over link pytosquatting.org

### DIFF
--- a/packages.rst
+++ b/packages.rst
@@ -109,10 +109,6 @@ fate0:
   * ztz
   * ...
 
-See also:
-
-* `pytosquatting.org project <https://www.pytosquatting.org/>`_
-
 Example of typos:
 
 * ``urllib``, ``urllib2``: part of the standard library


### PR DESCRIPTION
The https://www.pytosquatting.org/ website is for a long time not related to the issue and most probably taken-over by third-parties.